### PR TITLE
Renaming Parser.XML to Parser.Xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-web-service-sdk",
-	"version": "0.1.0-develop.3",
+	"version": "0.1.0-develop.4",
 	"description": "Common services, controllers, and models for ChannelApe TypeScript and JavaScript web services.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -1,3 +1,3 @@
 import XmlParsingService from './service/XmlParsingService';
 
-export { XmlParsingService as XML };
+export { XmlParsingService as Xml };

--- a/test/parser/Parser.spec.ts
+++ b/test/parser/Parser.spec.ts
@@ -3,8 +3,8 @@ import { expect } from 'chai';
 import * as Parser from '../../src/parser/Parser';
 
 describe('Parser', () => {
-  it('Should export XML as a getter with XmlParsingService as the return value', () => {
-    expect(Parser.XML.toXml).to.be.a('function');
-    expect(Parser.XML.fromXml).to.be.a('function');
+  it('Should export Xml as a getter with XmlParsingService as the return value', () => {
+    expect(Parser.Xml.toXml).to.be.a('function');
+    expect(Parser.Xml.fromXml).to.be.a('function');
   });
 });


### PR DESCRIPTION
This will keep the export name in line with our Java naming conventions.