### PR TITLE
CA-4012 - Changing error report group ID to UUID so that it is unique

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -205,6 +205,15 @@
 			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
 			"integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
 		},
+		"@types/uuid": {
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
+			"integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "7.0.69"
+			}
+		},
 		"@types/xml2js": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-web-service-sdk",
-	"version": "0.2.0-develop.1",
+	"version": "0.2.0-develop.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-web-service-sdk",
-	"version": "0.2.0-develop.1",
+	"version": "0.2.0-develop.2",
 	"description": "Common services, controllers, and models for ChannelApe TypeScript and JavaScript web services.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"express": "^4.16.3",
 		"json2csv": "^4.2.1",
 		"moment": "^2.22.2",
+		"uuid": "^3.3.2",
 		"xml2js": "^0.4.19"
 	},
 	"devDependencies": {
@@ -71,6 +72,7 @@
 		"@types/node": "^7.0.63",
 		"@types/sinon": "^4.3.1",
 		"@types/sinon-express-mock": "^1.3.4",
+		"@types/uuid": "^3.4.4",
 		"@types/xml2js": "^0.4.3",
 		"app-root-path": "^2.0.1",
 		"chai": "^4.1.2",

--- a/src/report/service/ErrorReportingService.ts
+++ b/src/report/service/ErrorReportingService.ts
@@ -1,10 +1,9 @@
-import SqsMessageService from '../../aws/sqs/service/SqsMessageService';
 import { Logger, LogLevel } from 'channelape-logger';
+import * as uuid from 'uuid';
 
+import SqsMessageService from '../../aws/sqs/service/SqsMessageService';
 import ErrorReport from '../model/ErrorReport';
 import AwsCredentials from '../../aws/model/AwsCredentials';
-
-const SQS_MESSAGE_GROUP_ID = 'Error_Reports';
 
 export default class ErrorReportingService {
   private readonly sqsMessageService: SqsMessageService;
@@ -35,7 +34,7 @@ export default class ErrorReportingService {
       channelApeOrder: `https://${this.channelApeWebAppDomainName}/orders/${errorReport.channelApeOrderId}`,
       message: errorReport.message
     };
-    this.sqsMessageService.sendMessage(message, SQS_MESSAGE_GROUP_ID)
+    this.sqsMessageService.sendMessage(message, uuid.v4())
       .catch(err => this.logger.error('Failed to queue the following error: ' +
         `${JSON.stringify(message)} because: ${err}`));
   }


### PR DESCRIPTION
@Keeleon Discovered that if the error reports are queued with unique message group IDs there is no issue with retrieving more than 10 at a time due to a SO question that was answered *three hours ago* 

This PR removes the constant message group ID and replaces it with a UUIDv4.