### PR TITLE
CA-4163 - Removing ChannelApe order from error report when undefined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-web-service-sdk",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,16 @@
 			"integrity": "sha512-S5NC8HV6HnRipg8nC0j30TPl7ktXjRTKqgyINLNe8K/64UJUI8Lq0sRopXC0hProsV2F5ibj8IqPkl1xpGggrw==",
 			"dev": true
 		},
+		"@types/nodemailer": {
+			"version": "4.6.5",
+			"resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-4.6.5.tgz",
+			"integrity": "sha512-cbs2HFLj33TBqzcCqTrs+6/mgTX3xl0odbApv3vTdF2+JERLxh5rDZCasXhvy+YqaiUNBr2I1RjNCdbKGs1Bnw==",
+			"dev": true,
+			"requires": {
+				"@types/events": "1.2.0",
+				"@types/node": "7.0.69"
+			}
+		},
 		"@types/q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
@@ -2046,6 +2056,11 @@
 					"dev": true
 				}
 			}
+		},
+		"nodemailer": {
+			"version": "4.6.8",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.6.8.tgz",
+			"integrity": "sha512-A3s7EM/426OBIZbLHXq2KkgvmKbn2Xga4m4G+ZUA4IaZvG8PcZXrFh+2E4VaS2o+emhuUVRnzKN2YmpkXQ9qwA=="
 		},
 		"nopt": {
 			"version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "channelape-web-service-sdk",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Common services, controllers, and models for ChannelApe TypeScript and JavaScript web services.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"express": "^4.16.3",
 		"json2csv": "^4.2.1",
 		"moment": "^2.22.2",
+		"nodemailer": "^4.6.8",
 		"uuid": "^3.3.2",
 		"xml2js": "^0.4.19"
 	},
@@ -70,11 +71,12 @@
 		"@types/json2csv": "^4.2.0",
 		"@types/mocha": "^2.2.48",
 		"@types/node": "^7.0.63",
+		"@types/nodemailer": "^4.6.5",
+		"@types/q": "^1.5.1",
 		"@types/sinon": "^4.3.1",
 		"@types/sinon-express-mock": "^1.3.4",
 		"@types/uuid": "^3.4.4",
 		"@types/xml2js": "^0.4.3",
-		"@types/q": "^1.5.1",
 		"app-root-path": "^2.0.1",
 		"chai": "^4.1.2",
 		"concurrently": "^3.5.1",
@@ -84,6 +86,7 @@
 		"mocha-typescript": "^1.1.12",
 		"node-rest-client": "^3.1.0",
 		"nyc": "^11.7.1",
+		"q": "^1.5.1",
 		"sinon": "^4.5.0",
 		"sinon-express-mock": "^2.0.4",
 		"stryker": "^0.29.0",
@@ -95,8 +98,7 @@
 		"ts-node": "^6.1.1",
 		"tslint": "^5.9.1",
 		"tslint-config-airbnb": "^5.8.0",
-		"typescript": "^2.8.3",
-		"q": "^1.5.1"
+		"typescript": "^2.8.3"
 	},
 	"nyc": {
 		"include": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,5 @@ export { default as AdditionalFieldService } from './channelape/service/Addition
 export { default as ErrorReportModule } from './report/model/ErrorReportModule';
 export { default as ErrorReport } from './report/model/ErrorReport';
 export { default as ErrorReportingService } from './report/service/ErrorReportingService';
+export { default as SendMailService } from './report/service/SendMailService';
+export { default as SendMailRequest } from './report/model/SendMailRequest';

--- a/src/report/model/SendMailRequest.ts
+++ b/src/report/model/SendMailRequest.ts
@@ -1,0 +1,7 @@
+export default interface SendMailRequest {
+  recipientsCsv: string;
+  from: string;
+  subject: string;
+  body: string;
+  attachments?: { fileContent: string; fileName: string; }[];
+}

--- a/src/report/service/ErrorReportingService.ts
+++ b/src/report/service/ErrorReportingService.ts
@@ -27,11 +27,12 @@ export default class ErrorReportingService {
   }
 
   public queueError(errorReport: ErrorReport): void {
+    const channelApeOrderUrl = `https://${this.channelApeWebAppDomainName}/orders/${errorReport.channelApeOrderId}`;
     const message = {
       module: errorReport.module,
       channelOrderId: errorReport.channelOrderId,
       poNumber: errorReport.poNumber,
-      channelApeOrder: `https://${this.channelApeWebAppDomainName}/orders/${errorReport.channelApeOrderId}`,
+      channelApeOrder: errorReport.channelApeOrderId ? channelApeOrderUrl : undefined,
       message: errorReport.message
     };
     this.sqsMessageService.sendMessage(message, uuid.v4())

--- a/src/report/service/SendMailService.ts
+++ b/src/report/service/SendMailService.ts
@@ -1,0 +1,48 @@
+import { Transporter, SendMailOptions, createTransport } from 'nodemailer';
+import { SES } from 'aws-sdk';
+
+import AwsCredentials from '../../aws/model/AwsCredentials';
+import SendMailRequest from '../model/SendMailRequest';
+
+export default class SendMailService {
+  private readonly nodemailerSesTransporter: Transporter;
+
+  constructor(awsCredentials: AwsCredentials) {
+    this.nodemailerSesTransporter = createTransport({
+      SES: new SES({
+        secretAccessKey: awsCredentials.secretKey,
+        accessKeyId: awsCredentials.accessKeyId,
+        region: awsCredentials.region,
+        apiVersion: '2010-12-01'
+      })
+    });
+  }
+
+  public sendMail(sendMailRequest: SendMailRequest): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const sendMailOptions: SendMailOptions = {
+        to: sendMailRequest.recipientsCsv,
+        from: sendMailRequest.from,
+        subject: sendMailRequest.subject,
+        text: sendMailRequest.body
+      };
+      if (sendMailRequest.attachments) {
+        sendMailRequest.attachments.forEach((attachment) => {
+          if (!sendMailOptions.attachments) {
+            sendMailOptions.attachments = [];
+          }
+          sendMailOptions.attachments.push({
+            filename: attachment.fileName,
+            content: attachment.fileContent
+          });
+        });
+      }
+      this.nodemailerSesTransporter.sendMail(sendMailOptions, (err, info) => {
+        if (err) {
+          return reject(`Error sending email: ${err}`);
+        }
+        resolve(info);
+      });
+    });
+  }
+}

--- a/test/report/service/SendEmailService.spec.ts
+++ b/test/report/service/SendEmailService.spec.ts
@@ -1,0 +1,138 @@
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import * as nodemailer from 'nodemailer';
+
+import SendMailService from '../../../src/report/service/SendMailService';
+import SendMailRequest from '../../../src/report/model/SendMailRequest';
+
+describe('ErrorReportingService', () => {
+  const sandbox = sinon.createSandbox();
+  let sendMailStub = sinon.stub();
+  let sendMailRequest: SendMailRequest;
+
+  beforeEach(() => {
+    sendMailRequest = {
+      recipientsCsv: 'recipient-email-address',
+      from: 'noreply@channelapeservices.com',
+      subject: 'ChannelApe Allbirds UK Web Service Report - formatted-date',
+      body: 'Attached is a report containing items of interest from the latest ChannelApe Sync'
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('sendMail()', () => {
+    context('Given no attachment', () => {
+      it('should send the email with correct from, subject, text, and no attachment', () => {
+        stubSendEmailSuccess();
+        const sendMailService = getNewSendMailService();
+        return sendMailService.sendMail(sendMailRequest)
+          .then(() => {
+            const fromAddress = sendMailStub.args[0][0].from;
+            const subject = sendMailStub.args[0][0].subject;
+            const text = sendMailStub.args[0][0].text;
+            expect(fromAddress).to.equal('noreply@channelapeservices.com');
+            expect(subject).to.equal('ChannelApe Allbirds UK Web Service Report - formatted-date');
+            expect(text).to.equal('Attached is a report containing items of interest from the latest ChannelApe Sync');
+            expect(sendMailStub.calledOnce).to.be.true;
+            expect(sendMailStub.args[0][0].attachments).to.be.undefined;
+          });
+      });
+    });
+
+    context('Given an attachment', () => {
+      it('should send the email with correct from, subject, text, and an attachment', () => {
+        stubSendEmailSuccess();
+        const expectedAttachmentContent = 'attachment-content';
+        const expectedAttachmentName = 'attachment-name.csv';
+        sendMailRequest.attachments = [{ fileName: expectedAttachmentName, fileContent: expectedAttachmentContent }];
+        const sendMailService = getNewSendMailService();
+        return sendMailService.sendMail(sendMailRequest)
+          .then(() => {
+            const fromAddress = sendMailStub.args[0][0].from;
+            const subject = sendMailStub.args[0][0].subject;
+            const text = sendMailStub.args[0][0].text;
+            expect(fromAddress).to.equal('noreply@channelapeservices.com');
+            expect(subject).to.equal('ChannelApe Allbirds UK Web Service Report - formatted-date');
+            expect(text).to.equal('Attached is a report containing items of interest from the latest ChannelApe Sync');
+            expect(sendMailStub.calledOnce).to.be.true;
+            expect(sendMailStub.args[0][0].attachments).not.to.be.undefined;
+            expect(sendMailStub.args[0][0].attachments.length).to.equal(1);
+            expect(sendMailStub.args[0][0].attachments[0].filename).to.equal(expectedAttachmentName);
+            expect(sendMailStub.args[0][0].attachments[0].content).to.equal(expectedAttachmentContent);
+          });
+      });
+    });
+
+    context('Given multiple attachments', () => {
+      it('should send the email with correct from, subject, text, and an attachments', () => {
+        stubSendEmailSuccess();
+        sendMailRequest.attachments = [
+          { fileName: 'file1', fileContent: 'content1' },
+          { fileName: 'file2', fileContent: 'content2' },
+          { fileName: 'file3', fileContent: 'content3' }
+        ];
+        const sendMailService = getNewSendMailService();
+        return sendMailService.sendMail(sendMailRequest)
+          .then(() => {
+            const fromAddress = sendMailStub.args[0][0].from;
+            const subject = sendMailStub.args[0][0].subject;
+            const text = sendMailStub.args[0][0].text;
+            expect(fromAddress).to.equal('noreply@channelapeservices.com');
+            expect(subject).to.equal('ChannelApe Allbirds UK Web Service Report - formatted-date');
+            expect(text).to.equal('Attached is a report containing items of interest from the latest ChannelApe Sync');
+            expect(sendMailStub.calledOnce).to.be.true;
+            expect(sendMailStub.args[0][0].attachments).not.to.be.undefined;
+            expect(sendMailStub.args[0][0].attachments.length).to.equal(3);
+            expect(sendMailStub.args[0][0].attachments[0].filename).to.equal('file1');
+            expect(sendMailStub.args[0][0].attachments[0].content).to.equal('content1');
+            expect(sendMailStub.args[0][0].attachments[1].filename).to.equal('file2');
+            expect(sendMailStub.args[0][0].attachments[1].content).to.equal('content2');
+            expect(sendMailStub.args[0][0].attachments[2].filename).to.equal('file3');
+            expect(sendMailStub.args[0][0].attachments[2].content).to.equal('content3');
+          });
+      });
+    });
+
+    context('Given an error when sending the email', () => {
+      it('should should reject', () => {
+        stubSendEmailError();
+        const sendMailService = getNewSendMailService();
+        return sendMailService.sendMail(sendMailRequest)
+          .then(() => {
+            throw new Error('Should not have resolved');
+          })
+          .catch((e) => {
+            expect(e).to.equal('Error sending email: Error: COULD NOT SEND EMAIL');
+          });
+      });
+    });
+  });
+
+  function stubSendEmailError() {
+    sendMailStub = sandbox.stub().callsFake((params: any, cb: Function) => {
+      cb(new Error('COULD NOT SEND EMAIL'), undefined);
+    });
+    sandbox.stub(nodemailer, 'createTransport')
+      .callsFake((params) => {
+        expect(params.SES.config.apiVersion).to.equal('2010-12-01');
+        return {
+          sendMail: sendMailStub
+        };
+      });
+  }
+
+  function stubSendEmailSuccess() {
+    sendMailStub = sandbox.stub().callsFake((params: any, cb: Function) => {
+      cb(undefined, 'All good!');
+    });
+    sandbox.stub(nodemailer, 'createTransport')
+      .returns({
+        sendMail: sendMailStub
+      });
+  }
+
+  function getNewSendMailService(): SendMailService {
+    return new SendMailService({ accessKeyId: 'access-key-id', region: 'us-east-1', secretKey: 'secret-key' });
+  }
+});


### PR DESCRIPTION
The Error Report interface does not require the ChannelApe order ID, however when the ID is undefined it will add ChannelApe order URL as `https://app.channelape.com/order/undefined` to the error report instead of leaving the field blank.  This PR fixes this.